### PR TITLE
Update ruby version to latest 2.1.5

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 ruby_library_version:   "2.1.0"
 ruby_version:           "ruby-2.1.5"
-ruby_checksum:          "f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635"
+ruby_checksum:          "df4c1b23f624a50513c7a78cb51a13dc"
 ruby_download_location: "http://cache.ruby-lang.org/pub/ruby/2.1/{{ ruby_version }}.tar.gz"
 ruby_bundler_flags: "--no-document"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 ruby_library_version:   "2.1.0"
-ruby_version:           "ruby-2.1.2"
+ruby_version:           "ruby-2.1.5"
 ruby_checksum:          "f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635"
 ruby_download_location: "http://cache.ruby-lang.org/pub/ruby/2.1/{{ ruby_version }}.tar.gz"
 ruby_bundler_flags: "--no-document"


### PR DESCRIPTION
Not too important, but there have been a couple of ruby security related updates recently and thought it'd be good set to the newest as a default.
